### PR TITLE
Test `NufftProjection` by installing `jax-finufft` in testing workflow

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           uv venv --python=${{ matrix.python-version }}
           uv pip install --upgrade pip
-          uv pip install '.[dev,docs,tests]'
+          uv pip install '.[dev,docs,tests,extras]'
 
       - name: Checks with pre-commit
         run: |

--- a/cryojax/simulator/_volume_integrator/nufft_projection.py
+++ b/cryojax/simulator/_volume_integrator/nufft_projection.py
@@ -115,7 +115,15 @@ class NufftProjection(
 
 
 def _project_with_nufft(weights, coordinate_list, shape, eps=1e-6):
-    from jax_finufft import nufft1
+    try:
+        from jax_finufft import nufft1  # type: ignore
+    except ModuleNotFoundError as err:
+        raise RuntimeError(
+            "Tried to compute a projection using the `NufftProjection` "
+            "class, but `jax-finufft` is not installed. "
+            "See https://github.com/flatironinstitute/jax-finufft "
+            "for installation instructions."
+        ) from err
 
     weights, coordinate_list = (
         jnp.asarray(weights, dtype=complex),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ tests = [
     "pycistem; sys_platform == 'linux' and python_version < '3.12'",
     "typeguard==2.13.3"
 ]
+extras = [
+    "jax-finufft"
+]
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -77,10 +77,10 @@ def test_projection_methods_no_pose(sample_pdb_path, pixel_size, shape):
                 projection_by_other_method = compute_projection(
                     volume, projection_method, image_config
                 )
-            except Exception as err:
+            except RuntimeError as err:
                 warnings.warn(
-                    "Could not test projection method `NufftProjection` "
-                    "This is most likely because `jax_finufft` is not installed. "
+                    "Could not test projection method `NufftProjection`, "
+                    "most likely because `jax_finufft` is not installed. "
                     f"Error traceback is:\n{err}"
                 )
                 continue


### PR DESCRIPTION
Also creates an installation category for dependencies of optional features.